### PR TITLE
JEQB-163/Changing the from_seed() and to_raw_vec functions in dilithium2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,9 +866,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
@@ -12370,9 +12370,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -32,7 +32,7 @@ substrate-bip39 = { version = "0.4.4", optional = true }
 tiny-bip39 = { version = "0.8.2", optional = true }
 regex = { version = "1.5.4", optional = true }
 num-traits = { version = "0.2.8", default-features = false }
-zeroize = { version = "1.4.3", default-features = false }
+zeroize = { version = "1.5.7", default-features = false }
 secrecy = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.0", optional = true }

--- a/primitives/core/src/dilithium2.rs
+++ b/primitives/core/src/dilithium2.rs
@@ -431,11 +431,17 @@ impl TraitPair for Pair {
 		let seed = Seed::default();
 		Ok((Self::from_seed(&seed), Some(seed)))
 	}
-	fn from_seed(_: &Self::Seed) -> Self {
-		let public_bytes: Vec<u8> = (0..1312).map(|_| { rand::random::<u8>() }).collect();
-		let public = Public(<[u8; 1312]>::try_from(public_bytes.as_slice()).unwrap());
-		let secret_bytes: Vec<u8> = (0..2528).map(|_| { rand::random::<u8>() }).collect();
-		let secret = Secret(<[u8; 2528]>::try_from(secret_bytes.as_slice()).unwrap());
+	fn from_seed(seed: &Self::Seed) -> Self {
+		let mut public_bytes_array: [u8; 1312] = [0;1312];
+		for i in 0..41 {
+			public_bytes_array[i*32..i*32+32].copy_from_slice(seed.as_slice());
+		}
+		let mut secret_bytes_array: [u8; 2528] = [0;2528];
+		for i in 0..79 {
+			secret_bytes_array[i*32..i*32+32].copy_from_slice(seed.as_slice());
+		}
+		let public = Public(public_bytes_array);
+		let secret = Secret(secret_bytes_array);
 
 		Pair { public, secret }
 	}
@@ -457,7 +463,10 @@ impl TraitPair for Pair {
 		self.public
 	}
 	fn to_raw_vec(&self) -> Vec<u8> {
-		Vec::new()
+		let mut vec_1 = self.secret.0.to_vec();
+		let mut vec_2 = self.public.0.to_vec();
+		vec_1.append(&mut vec_2);
+		vec_1
 	}
 }
 

--- a/primitives/core/src/dilithium2.rs
+++ b/primitives/core/src/dilithium2.rs
@@ -446,8 +446,10 @@ impl TraitPair for Pair {
 		Pair { public, secret }
 	}
 
-	fn from_seed_slice(_: &[u8]) -> Result<Self, SecretStringError> {
-		Ok(Self::from_seed(&Seed::default()))
+	fn from_seed_slice(seed: &[u8]) -> Result<Self, SecretStringError> {
+		let mut s: [u8;32] = [0;32];
+		s.copy_from_slice(seed);
+		Ok(Self::from_seed(&s))
 	}
 	fn sign(&self, _: &[u8]) -> Self::Signature {
 		let sig_bytes: Vec<u8> = (0..2420).map(|_| { rand::random::<u8>() }).collect();


### PR DESCRIPTION
The from_seed() function no longer generates keys from random bytes, but fils them with bytes from seed.
The to_raw_vec() function now does not return an empty vector, but returns a vector containing secret key bytes and public key bytes.